### PR TITLE
메시지 반응을 http에서 websocket으로 전환

### DIFF
--- a/src/features/chat-room/ChatRoom.tsx
+++ b/src/features/chat-room/ChatRoom.tsx
@@ -10,6 +10,7 @@ import {
     messageReactionService,
     type ReactionType,
     useContextMenu,
+    normalizeReactions,
     // Message Management Hooks (FSD 원칙 준수)
     useMessageState,
     useMessageHandlers,
@@ -364,7 +365,9 @@ const ChatRoom = ({ roomId }: { roomId: string }) => {
                     setMessages(prevMessages => {
                         const updatedMessages = prevMessages.map(message => {
                             if (message.id === reactionUpdate.messageId) {
-                                return { ...message, reactions: reactionUpdate.reactions };
+                                // 백엔드 Record<string, number[]>를 ReactionItem[]로 변환
+                                const convertedReactions = normalizeReactions(reactionUpdate.reactions);
+                                return { ...message, reactions: convertedReactions };
                             }
                             return message;
                         });

--- a/src/features/chat-room/ChatRoom.tsx
+++ b/src/features/chat-room/ChatRoom.tsx
@@ -8,7 +8,6 @@ import { markAllMessagesAsRead } from "../../shared/api/messages";
 import { 
     createWebSocketService,
     messageReactionService,
-    hasReactionType,
     type ReactionType,
     useContextMenu,
     // Message Management Hooks (FSD 원칙 준수)
@@ -355,6 +354,22 @@ const ChatRoom = ({ roomId }: { roomId: string }) => {
                 // 핀 상태 변경 핸들러 - React Query 무효화
                 webSocketService.current.onPinUpdate(() => {
                     invalidatePinnedMessages();
+                });
+
+                // Reaction 서비스 설정 및 핸들러
+                messageReactionService.setWebSocketService(webSocketService.current);
+                
+                // Reaction 업데이트 핸들러
+                webSocketService.current.onReactionUpdate((reactionUpdate) => {
+                    setMessages(prevMessages => {
+                        const updatedMessages = prevMessages.map(message => {
+                            if (message.id === reactionUpdate.messageId) {
+                                return { ...message, reactions: reactionUpdate.reactions };
+                            }
+                            return message;
+                        });
+                        return updatedMessages;
+                    });
                 });
 
                 // 동기화 핸들러
@@ -742,23 +757,17 @@ const ChatRoom = ({ roomId }: { roomId: string }) => {
 
     // 읽음 상태 계산 로직은 MessagesList 컴포넌트로 이동됨
 
-    // 리액션 선택 핸들러 - 메모이제이션 및 스크롤 자동 조정
+    // 리액션 선택 핸들러 - WebSocket 기반으로 변경
     const handleReactionSelect = useCallback(async (reactionType: string) => {
-        if (!contextMenu.message) return;
+        if (!contextMenu.message) {
+            return;
+        }
         
         try {
-            const hasReacted = hasReactionType(contextMenu.message.reactions, reactionType, user?.id || 0);
-            const response = hasReacted
-                ? await messageReactionService.removeReaction(contextMenu.message.id, reactionType)
-                : await messageReactionService.addReaction(contextMenu.message.id, reactionType);
+            // WebSocket을 통해 반응 토글 (백엔드에서 자동으로 add/remove 판단)
+            await messageReactionService.toggleReaction(contextMenu.message.id, reactionType);
             
-            setMessages(prevMessages =>
-                prevMessages.map(message =>
-                    message.id === contextMenu.message?.id
-                        ? { ...message, reactions: response.reactions }
-                        : message
-                )
-            );
+            // 반응 업데이트는 WebSocket 핸들러에서 자동 처리되므로 별도 상태 업데이트 불필요
             
             // 리액션 업데이트 후 스크롤 자동 조정 (화면 하단 근처에 있을 때만)
             if (isNearBottom.current) {
@@ -770,9 +779,9 @@ const ChatRoom = ({ roomId }: { roomId: string }) => {
             setShowReactionPicker(false);
             closeContextMenu();
         } catch (error) {
-            console.error('리액션 처리 중 오류 발생:', error);
+            console.error('❌ 리액션 처리 중 오류 발생:', error);
         }
-    }, [contextMenu.message, user?.id, setMessages, setShowReactionPicker, closeContextMenu, isNearBottom, scrollToBottom]);
+    }, [contextMenu.message, setShowReactionPicker, closeContextMenu, isNearBottom, scrollToBottom]);
 
     // 반응 추가 버튼 클릭 핸들러
     const handleShowReactionPicker = (e: React.MouseEvent) => {

--- a/src/features/chat-room/ui/MessageRow.tsx
+++ b/src/features/chat-room/ui/MessageRow.tsx
@@ -226,8 +226,15 @@ const MessageRowComponent: React.FC<MessageRowProps> = ({
 // React.memo로 렌더링 최적화 - 메시지별 개별 메모이제이션
 export const MessageRow = memo(MessageRowComponent, (prevProps, nextProps) => {
     // 메시지 내용, 상태, 시간 표시 여부 등이 동일하면 리렌더링 하지 않음
+    const messageChanged = (
+        prevProps.message.id !== nextProps.message.id ||
+        prevProps.message.content !== nextProps.message.content ||
+        prevProps.message.status !== nextProps.message.status ||
+        JSON.stringify(prevProps.message.reactions) !== JSON.stringify(nextProps.message.reactions) // reactions 깊은 비교
+    );
+    
     return (
-        prevProps.message === nextProps.message &&
+        !messageChanged &&
         prevProps.isOwn === nextProps.isOwn &&
         prevProps.showTime === nextProps.showTime &&
         prevProps.currentTime === nextProps.currentTime &&

--- a/src/shared/lib/types/common.ts
+++ b/src/shared/lib/types/common.ts
@@ -18,8 +18,8 @@ export interface ReactionType {
 export interface MessageReactionProps {
     messageId: string;
     userId?: number;
-    reactions?: any[];
-    onReactionUpdate?: (messageId: string, reactions: any[]) => void;
+    reactions?: import('../../../entities/message').ReactionItem[];
+    onReactionUpdate?: (messageId: string, reactions: Record<string, number[]>) => void;
 }
 
 // 컨텍스트 메뉴 관련 타입

--- a/src/shared/lib/websocket/types.ts
+++ b/src/shared/lib/websocket/types.ts
@@ -13,6 +13,12 @@ export interface WebSocketMessage {
     limit?: number;
 }
 
+export interface Reaction {
+    userId: number;
+    reactionType: string;
+    createdAt?: string;
+}
+
 export interface ReactionRequest {
     messageId: string;
     reactionType: string;
@@ -21,7 +27,7 @@ export interface ReactionRequest {
 
 export interface ReactionUpdateMessage {
     messageId: string;
-    reactions: any[];
+    reactions: Record<string, number[]>; // 백엔드에서 집계된 형태로 전송
     userId: number;
     reactionType: string;
     action: 'ADDED' | 'REMOVED';
@@ -32,7 +38,7 @@ export interface ReactionResponse {
     message: string;
     data: {
         messageId: string;
-        reactions: any[];
+        reactions: Reaction[];
         updatedAt: string;
     } | null;
 }

--- a/src/shared/lib/websocket/types.ts
+++ b/src/shared/lib/websocket/types.ts
@@ -13,6 +13,30 @@ export interface WebSocketMessage {
     limit?: number;
 }
 
+export interface ReactionRequest {
+    messageId: string;
+    reactionType: string;
+    userId: number;
+}
+
+export interface ReactionUpdateMessage {
+    messageId: string;
+    reactions: any[];
+    userId: number;
+    reactionType: string;
+    action: 'ADDED' | 'REMOVED';
+}
+
+export interface ReactionResponse {
+    success: boolean;
+    message: string;
+    data: {
+        messageId: string;
+        reactions: any[];
+        updatedAt: string;
+    } | null;
+}
+
 export interface WebSocketService {
     connect(roomId: number, userId: number): Promise<void>;
     disconnect(): void;
@@ -26,6 +50,10 @@ export interface WebSocketService {
     onReadBulk(callback: (data: { messageIds: string[], userId: number }) => void): void;
     onPinUpdate(callback: () => void): void;
     onSync(callback: (syncResponse: { roomId: number, direction?: string, messages: any[] }) => void): void;
+    // Reaction 관련 메서드 추가
+    sendReaction(messageId: string, reactionType: string): void;
+    onReactionUpdate(callback: (update: ReactionUpdateMessage) => void): void;
+    onReactionResponse(callback: (response: ReactionResponse) => void): void;
     clearAllHandlers(): void;
     markAllMessagesAsRead(): void;
     sendTypingIndicator(isTyping: boolean): void;


### PR DESCRIPTION
메시지 반응을 http에서 websocket으로 전환

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 채팅방에서 실시간 메시지 반응 업데이트가 WebSocket을 통해 제공되어, 사용자들이 즉시 반응을 확인할 수 있습니다.
  * 메시지에 대한 반응을 즉각적으로 추가하거나 제거할 수 있으며, 다른 사용자의 반응도 실시간으로 볼 수 있습니다.

* **Refactor**
  * 반응 처리 방식을 REST API에서 WebSocket 기반으로 전환하여 반응 동기화와 응답성을 개선했습니다.
  * 메시지 반응 관련 상태 관리를 WebSocket 서버 푸시 이벤트 중심으로 변경했습니다.

* **Bug Fixes**
  * 반응 업데이트 처리 시 JSON 파싱 오류 등 예외 상황에 대한 에러 핸들링을 강화했습니다.

* **Style**
  * 메시지 컴포넌트의 리렌더링 조건을 개선하여 반응, 내용, 상태 변경 시에만 업데이트되도록 최적화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->